### PR TITLE
Use a component for Codedeploy

### DIFF
--- a/components/22.04/install_codedeploy_agent.yml
+++ b/components/22.04/install_codedeploy_agent.yml
@@ -1,7 +1,7 @@
 name: InstallCodedeployAgent
 description: Installs AWS CodedeployAgent
 schemaVersion: 1.0
-component_version: 0.0.2
+component_version: 0.0.3
 
 phases:
   - name: build
@@ -17,12 +17,13 @@ phases:
           commands:
             - cd /tmp
             - wget https://aws-codedeploy-us-east-1.s3.us-east-1.amazonaws.com/releases/codedeploy-agent_1.3.2-1902_all.deb
-            - mkdir codedeploy-agent_1.3.2-1902_ubuntu22
-            - dpkg-deb -R codedeploy-agent_1.3.2-1902_all.deb codedeploy-agent_1.3.2-1902_ubuntu22
-            - sed 's/Depends:.*/Depends:ruby3.0/' -i ./codedeploy-agent_1.3.2-1902_ubuntu22/DEBIAN/control
-            - dpkg-deb -b codedeploy-agent_1.3.2-1902_ubuntu22/
-            - sudo dpkg -i codedeploy-agent_1.3.2-1902_ubuntu22.deb
-
+            - VERSION=$(aws s3 ls s3://aws-codedeploy-eu-west-2/releases/ | grep deb | sort --reverse | head -n 1 | cut -c 49-58)
+            - wget https://aws-codedeploy-us-east-1.s3.us-east-1.amazonaws.com/releases/codedeploy-agent_"$VERSION"_all.deb
+            - mkdir codedeploy-agent_"$VERSION"_ubuntu22
+            - dpkg-deb -R codedeploy-agent_"$VERSION"_all.deb codedeploy-agent_"$VERSION"_ubuntu22
+            - sed 's/Depends:.*/Depends:ruby3.0/' -i ./codedeploy-agent_"$VERSION"_ubuntu22/DEBIAN/control
+            - dpkg-deb -b codedeploy-agent_"$VERSION"_ubuntu22/
+            - sudo dpkg -i codedeploy-agent_"$VERSION"_ubuntu22.deb
 
   - name: test
     steps:

--- a/components/22.04/install_codedeploy_agent.yml
+++ b/components/22.04/install_codedeploy_agent.yml
@@ -1,0 +1,34 @@
+name: InstallCodedeployAgent
+description: Installs AWS CodedeployAgent
+schemaVersion: 1.0
+component_version: 0.0.2
+
+phases:
+  - name: build
+    steps:
+      - name: InstallAptPackages
+        action: ExecuteBash
+        inputs:
+          commands:
+            - sudo apt install -y ruby-full ruby-webrick wget
+      - name: InstallDebPackage
+        action: ExecuteBash
+        inputs:
+          commands:
+            - cd /tmp
+            - wget https://aws-codedeploy-us-east-1.s3.us-east-1.amazonaws.com/releases/codedeploy-agent_1.3.2-1902_all.deb
+            - mkdir codedeploy-agent_1.3.2-1902_ubuntu22
+            - dpkg-deb -R codedeploy-agent_1.3.2-1902_all.deb codedeploy-agent_1.3.2-1902_ubuntu22
+            - sed 's/Depends:.*/Depends:ruby3.0/' -i ./codedeploy-agent_1.3.2-1902_ubuntu22/DEBIAN/control
+            - dpkg-deb -b codedeploy-agent_1.3.2-1902_ubuntu22/
+            - sudo dpkg -i codedeploy-agent_1.3.2-1902_ubuntu22.deb
+
+
+  - name: test
+    steps:
+      - name: CheckCodedeployAgent
+        action: ExecuteBash
+        inputs:
+          commands:
+            - systemctl list-units --type=service | grep codedeploy
+            - sudo service codedeploy-agent status

--- a/settings.json
+++ b/settings.json
@@ -2,7 +2,7 @@
   "supported_ubuntu_versions": {
     "22.04": {
       "base_ami": "ami-08faca8d0701614ab",
-      "recipe_version": "0.0.7",
+      "recipe_version": "0.0.8",
       "components": [
         {
           "name": "ubuntu_upgrades",
@@ -26,7 +26,7 @@
         },
         {
           "name": "amazon-codedeploy-agent-linux",
-          "arn": "arn:aws:imagebuilder:eu-west-2:aws:component/aws-codedeploy-agent-linux/x.x.x"
+          "arn": "install_codedeploy_agent.yml"
         }
       ]
     }


### PR DESCRIPTION
Installing codedeploy on 22.04 is painful because of ruby versions. This component is lifted from here:
https://github.com/aws/aws-codedeploy-agent/issues/301#issuecomment-1129912011